### PR TITLE
Add reference to $this in object context

### DIFF
--- a/BitsoAPI/bitso.php
+++ b/BitsoAPI/bitso.php
@@ -324,7 +324,7 @@ class bitso
     $JSONPayload = '';
     $type = 'PRIVATE';
 
-    return getData($nonce,$path,$RequestPath,$HTTPMethod,$JSONPayload,$type);
+    return $this->getData($nonce,$path,$RequestPath,$HTTPMethod,$JSONPayload,$type);
   }
 
   function user_trades($params, $ids=[]){


### PR DESCRIPTION
The order_trades function invokes getData method without using $this in object context. This needs to be fixed to make it work properly.